### PR TITLE
Use the effective path to determine mime type

### DIFF
--- a/unikernel.ml
+++ b/unikernel.ml
@@ -119,7 +119,10 @@ module Main
             in
             lookup path >>= function
             | Ok r -> Lwt.return_ok (path, r)
-            | Error _ -> lookup (path ^ "/index.html")
+            | Error _ ->
+              let effective_path = path ^ "/index.html" in
+              Lwt_result.map (fun r -> effective_path, r)
+                (lookup effective_path)
           in
           find path >>= function
           | Ok (effective_path, data) ->

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -118,13 +118,13 @@ module Main
               Store.get store (Mirage_kv.Key.v path)
             in
             lookup path >>= function
-            | Ok _ as r -> Lwt.return r
+            | Ok r -> Lwt.return_ok (path, r)
             | Error _ -> lookup (path ^ "/index.html")
           in
           find path >>= function
-          | Ok data ->
+          | Ok (effective_path, data) ->
             let headers = [
-              "content-type", mime_type path ;
+              "content-type", mime_type effective_path ;
               "etag", Last_modified.etag () ;
               "last-modified", Last_modified.last_modified () ;
               "content-length", string_of_int (String.length data) ;


### PR DESCRIPTION
If a lookup fails we try again with $path/index.html - and we should use that for determining the mime type.

Should fix #16.