### PR TITLE
Add support for redirects via symbolic links

### DIFF
--- a/unikernel.ml
+++ b/unikernel.ml
@@ -223,17 +223,21 @@ module Main
           Lwt.async @@ fun () ->
           let find path =
             let lookup path =
-              Git_kv.get store (Mirage_kv.Key.v path)
+              Git_kv.get_with_permissions store (Mirage_kv.Key.v path)
             in
             lookup path >>= function
             | Ok r -> Lwt.return_ok (path, r)
             | Error _ ->
               let effective_path = path ^ "/index.html" in
-              Lwt_result.map (fun r -> effective_path, r)
+              Lwt_result.map (fun (perm, data) -> effective_path, perm, data)
                 (lookup effective_path)
           in
           find path >>= function
-          | Ok (effective_path, data) ->
+          | Ok (effective_path, `Link, data) ->
+            (* XXX(reynir): we could and should sanitize [data] *)
+            let headers = [ "location", data ] in
+            H1.Response.create ~headers `Moved_permanently
+          | Ok (effective_path, _perm, data) ->
             let headers = [
               "content-type", mime_type effective_path ;
               "etag", Last_modified.etag () ;

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -234,7 +234,6 @@ module Main
           in
           find path >>= function
           | Ok (effective_path, `Link, data) ->
-            (* XXX(reynir): we could and should sanitize [data] *)
             let headers = [ "location", data ] in
             let headers = H1.Headers.of_list headers in
             let resp = H1.Response.create ~headers `Moved_permanently in

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -226,7 +226,7 @@ module Main
               Git_kv.get_with_permissions store (Mirage_kv.Key.v path)
             in
             lookup path >>= function
-            | Ok r -> Lwt.return_ok (path, r)
+            | Ok (perm, data) -> Lwt.return_ok (path, perm, data)
             | Error _ ->
               let effective_path = path ^ "/index.html" in
               Lwt_result.map (fun (perm, data) -> effective_path, perm, data)
@@ -236,7 +236,11 @@ module Main
           | Ok (effective_path, `Link, data) ->
             (* XXX(reynir): we could and should sanitize [data] *)
             let headers = [ "location", data ] in
-            H1.Response.create ~headers `Moved_permanently
+            let headers = H1.Headers.of_list headers in
+            let resp = H1.Response.create ~headers `Moved_permanently in
+            http_status resp;
+            H1.Reqd.respond_with_string reqd resp data ;
+            Lwt.return_unit
           | Ok (effective_path, _perm, data) ->
             let headers = [
               "content-type", mime_type effective_path ;


### PR DESCRIPTION
If a file in the git repository is a symbolic link then it's treated as a redirect - using the text string as the location for the redirect. E.g. adding `ln -s https://robur.coop/ link` in the git repository will make `/link` redirect to `https://robur.coop/`. In this implementation it's a permanent redirect, but we can consider other types of redirects (or a global configuration for the redirect type).

This doesn't compile as opam-monorepo isn't able to find a solution, and I don't quite understand what is blocking it and what I can do about it. I think the failure is caused by a dependency on `carton-git` somehow:

```
- carton-git -> (problem)
    carton 1.0.0 requires not(= 0.7.2)
    Rejected candidates:
      carton-git.0.7.2: Incompatible with restriction: not(= 0.7.2)
      carton-git.0.7.1+overlay: Requires carton = 0.7.1+overlay
      carton-git.0.7.1: Requires carton = 0.7.1
      carton-git.0.7.0+overlay: Requires carton = 0.7.0+overlay
      carton-git.0.7.0: Requires carton = 0.7.0
```

<details>
<summary>Full output</summary>

```
opam-monorepo: [ERROR] Can't find all required versions.
Selected: angstrom.0.16.1 arp.4.0.0 asn1-combinators.0.3.2 astring.0.8.5+dune
          awa.0.5.2 awa-mirage.0.5.2 base-bigarray.base base-bytes.base+dune
          base-domains.base base-effects.base base-nnp.base base-threads.base
          base-unix.base base64.3.5.1 bheap.2.0.0 bigstringaf.0.10.0
          bos.0.2.1+dune ca-certs-nss.3.108-1 cachet.0.0.2 cachet-lwt.0.0.2
          carton.1.0.0 carton-lwt.1.0.0 checkseum.0.5.2 cmdliner.1.3.0+dune
          cmdliner-stdlib.1.0.1 conf-gmp.5 conf-gmp-powm-sec.4 conf-m4.1
          cppo.1.8.0 csexp.1.5.2 cstruct.6.2.0 cstruct-lwt.6.2.0
          cstruct-unix.6.2.0 decompress.1.5.3 digestif.1.3.0 dns.10.1.0
          dns-client.10.1.0 dns-client-mirage.10.1.0 domain-name.0.4.1
          duff.0.5 dune.3.19.0 dune-configurator.3.19.0 duration.0.2.1
          emile.1.1 encore.0.8.1 eqaf.0.10 ethernet.3.2.0 faraday.0.8.2
          fmt.0.9.0+dune fpath.0.7.3+dune git.3.18.0 git-mirage.3.18.0
          git-paf.3.18.0 gmap.0.3.0 gmp.6.2.1-5 h1.1.0.0 h2.0.13.0
          happy-eyeballs.2.0.1 happy-eyeballs-mirage.2.0.1 hpack.0.13.0
          http-mirage-client.0.0.10 httpun-types.0.2.0 hxd.0.3.4 ipaddr.5.6.0
          ipaddr-cstruct.5.6.0 kdf.1.0.0 ke.0.6 letsencrypt.1.1.0
          letsencrypt-mirage.1.1.0 logs.0.7.0+dune2 lru.0.3.1 lwt.5.9.1
          lwt-dllist.1.1.0 macaddr.5.6.0 macaddr-cstruct.5.6.0
          magic-mime.1.3.1 metrics.0.4.1 metrics-lwt.0.4.1 mimic.0.0.9
          mimic-happy-eyeballs.0.0.9 mirage-bootvar.1.0.1 mirage-crypto.2.0.1
          mirage-crypto-ec.2.0.1 mirage-crypto-pk.2.0.1
          mirage-crypto-rng.2.0.1 mirage-crypto-rng-mirage.2.0.1
          mirage-flow.5.0.0 mirage-kv.6.1.1 mirage-logs.3.0.0
          mirage-mtime.5.0.0 mirage-net.4.0.0 mirage-net-solo5.0.8.0
          mirage-ptime.5.0.0 mirage-runtime.4.9.0 mirage-sleep.4.0.0
          mirage-solo5.0.10.0 mtime.2.0.0+dune ocaml-base-compiler.5.3.0
          ocaml-options-vanilla.1 ocaml-syntax-shims.1.0.0 ocamlgraph.2.2.0
          ocplib-endian.1.2 ohex.0.2.0 optint.0.3.0 paf.0.8.0 pecu.0.7
          psq.0.2.1 ptime.1.2.0+dune randomconv.0.2.0 result.1.5
          rresult.0.7.0+dune seq.base+dune stringext.1.6.0 tcpip.9.0.1
          tls.2.0.1 tls-mirage.2.0.1 unipi-hvt.zdev uri.4.4.0 uutf.1.0.3+dune
          x509.1.0.6 yojson.3.0.0 zarith.1.13+dune+mirage
          ocaml-base-compiler&unipi-hvt system-mingw
          system-mingw|system-msvc&winpthreads ocaml base-domains
          ocaml-variants ocaml-base-compiler gmp
- carton-git -> (problem)
    carton 1.0.0 requires not(= 0.7.2)
    Rejected candidates:
      carton-git.0.7.2: Incompatible with restriction: not(= 0.7.2)
      carton-git.0.7.1+overlay: Requires carton = 0.7.1+overlay
      carton-git.0.7.1: Requires carton = 0.7.1
      carton-git.0.7.0+overlay: Requires carton = 0.7.0+overlay
      carton-git.0.7.0: Requires carton = 0.7.0
      ...
- git-kv -> (problem)
    Rejected candidates:
      git-kv.dev: Requires fmt >= 0.10.0
- ocaml -> (problem)
    User requested = 4.14.2
    ocaml-compiler 5.3.0 requires = 5.3.0
    Rejected candidates:
      ocaml.4.14.2: Incompatible with restriction: = 5.3.0
- ocaml-compiler -> ocaml-compiler.5.3.0
    ocaml-base-compiler 5.3.0 requires = 5.3.0
- ocaml-variants -> (problem)
    Rejected candidates:
      ocaml-variants.5.5.0+trunk: In same conflict class (ocaml-core-compiler) as ocaml-base-compiler
      ocaml-variants.5.4.0+trunk: In same conflict class (ocaml-core-compiler) as ocaml-base-compiler
      ocaml-variants.5.4.0~alpha1+options: In same conflict class (ocaml-core-compiler) as ocaml-base-compiler
      ocaml-variants.5.3.1+trunk: In same conflict class (ocaml-core-compiler) as ocaml-base-compiler
      ocaml-variants.5.3.0+options: In same conflict class (ocaml-core-compiler) as ocaml-base-compiler
      ...
- system-mingw -> (problem)
    No known implementations at all
```

</details>

Depends on https://git.robur.coop/robur/git-kv/pulls/14