### PR TITLE
Add content-length header when redirecting

### DIFF
--- a/unikernel.ml
+++ b/unikernel.ml
@@ -234,7 +234,11 @@ module Main
           in
           find path >>= function
           | Ok (effective_path, `Link, data) ->
-            let headers = [ "location", data ] in
+            let headers = [
+              (* We let the client decide if [data] is a good URL *)
+              "location", data ;
+              "content-length", string_of_int (String.length data);
+            ] in
             let headers = H1.Headers.of_list headers in
             let resp = H1.Response.create ~headers `Moved_permanently in
             http_status resp;


### PR DESCRIPTION
Without this header I found curl would complain and hang:

```
$ curl -v http://192.168.111.27/bar
*   Trying 192.168.111.27:80...
* Connected to 192.168.111.27 (192.168.111.27) port 80
* using HTTP/1.x
> GET /bar HTTP/1.1
> Host: 192.168.111.27
> User-Agent: curl/8.14.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 301 Moved Permanently
< location: foo
* no chunk, no close, no size. Assume close to signal end
```

This suggests to me we never close the connection. Maybe we should. This patch makes curl happy though, and we do send data. Maybe Paf closes the connection if we send a content-length? CC @dinosaure 