### PR TITLE
Fix path when we receive a request such as /hook?data={abc}

### DIFF
--- a/unikernel.ml
+++ b/unikernel.ml
@@ -194,7 +194,7 @@ module Main
     let dispatch mime_type store hookf hook_url _conn reqd =
       let request = H1.Reqd.request reqd in
       let path =
-        Uri.(pct_decode (path (make ~path:request.H1.Request.target ())))
+        Uri.(pct_decode (path (of_string request.H1.Request.target)))
       in
       Logs.info (fun f -> f "requested %s" path);
       if String.equal hook_url path then


### PR DESCRIPTION
Previously, we constructed the Uri from that by providing the target as path, but what we really need to do is to have uri deal with the query parameters (?)

This helps with the recent webhooks being delivered by Forgejo.